### PR TITLE
remove webpack.django_integration.WebpackFinder from STATICFILES_FINDERS

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -89,7 +89,6 @@ STATICFILES_DIRS = local.STATICFILES_DIRS
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-    'webpack.django_integration.WebpackFinder',
 #    'django.contrib.staticfiles.finders.DefaultStorageFinder', 
 )
 


### PR DESCRIPTION
I get the following error any time I do anything in `tracker`,

```
Traceback (most recent call last):
  File "/home/edmund/.pyenv/versions/2.7.3/lib/python2.7/wsgiref/handlers.py", line 85, in run
    self.result = application(self.environ, self.start_response)
  File "/home/edmund/.pyenv/versions/2.7.3/lib/python2.7/site-packages/django/contrib/staticfiles/handlers.py", line 64, in __call__
    return super(StaticFilesHandler, self).__call__(environ, start_response)
  File "/home/edmund/.pyenv/versions/2.7.3/lib/python2.7/site-packages/django/core/handlers/wsgi.py", line 189, in __call__
    response = self.get_response(request)
  File "/home/edmund/.pyenv/versions/2.7.3/lib/python2.7/site-packages/django/contrib/staticfiles/handlers.py", line 54, in get_response
    return self.serve(request)
  File "/home/edmund/.pyenv/versions/2.7.3/lib/python2.7/site-packages/django/contrib/staticfiles/handlers.py", line 47, in serve
    return serve(request, self.file_path(request.path), insecure=True)
  File "/home/edmund/.pyenv/versions/2.7.3/lib/python2.7/site-packages/django/contrib/staticfiles/views.py", line 34, in serve
    absolute_path = finders.find(normalized_path)
  File "/home/edmund/.pyenv/versions/2.7.3/lib/python2.7/site-packages/django/contrib/staticfiles/finders.py", line 249, in find
    for finder in get_finders():
  File "/home/edmund/.pyenv/versions/2.7.3/lib/python2.7/site-packages/django/contrib/staticfiles/finders.py", line 264, in get_finders
    yield get_finder(finder_path)
  File "/home/edmund/.pyenv/versions/2.7.3/lib/python2.7/site-packages/django/utils/lru_cache.py", line 101, in wrapper
    result = user_function(*args, **kwds)
  File "/home/edmund/.pyenv/versions/2.7.3/lib/python2.7/site-packages/django/contrib/staticfiles/finders.py", line 273, in get_finder
    Finder = import_string(import_path)
  File "/home/edmund/.pyenv/versions/2.7.3/lib/python2.7/site-packages/django/utils/module_loading.py", line 26, in import_string
    module = import_module(module_path)
  File "/home/edmund/.pyenv/versions/2.7.3/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
ImportError: No module named webpack.django_integration
```

This removes that error.
