### PR TITLE
Put LC_ALL and LC_CTYPE in .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,3 +66,7 @@ HAS_AWS_FILE_STORAGE=False
 # AWS_SECRET_ACCESS_KEY=Iamasecretkey
 # AWS_STORAGE_BUCKET_NAME=some-image-bucket
 # AWS_DEFAULT_ACL=public-read
+
+# These are needed at all times on macOS and certain other distributions.
+LC_ALL=en_US.UTF-8
+LC_CTYPE=en_US.UTF-8

--- a/.envrc
+++ b/.envrc
@@ -5,6 +5,3 @@ nodeversion=$(head .node-version)
 
 use pyenv ${pyversion}
 use node ${nodeversion}
-
-export LC_ALL="en_US.UTF-8"
-export LC_CTYPE="en_US.UTF-8"


### PR DESCRIPTION
django-environ loads everything into os.environ, so we can leverage that
instead of using direnv.